### PR TITLE
Shorten two paths

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# biocro/boost version 1.0.1
+
+- This version shortens paths further to comply with CRAN requirements
+
 # biocro/boost version 1.0.0
 
 - This version is based on version 1.71.0 of the boost libraries, but changes

--- a/boost/atomic/detail/extra_fp_ops_generic.hpp
+++ b/boost/atomic/detail/extra_fp_ops_generic.hpp
@@ -30,7 +30,8 @@
 #if defined(BOOST_GCC) && (BOOST_GCC+0) >= 60000
 #pragma GCC diagnostic push
 // ignoring attributes on template argument X - this warning is because we need to pass storage_type as a template argument; no problem in this case
-#pragma GCC diagnostic ignored "-Wignored-attributes"
+#pragma GCC diagnostic\
+ ignored "-Wignored-attributes"
 #endif
 
 namespace boost {

--- a/boost/bind.hpp
+++ b/boost/bind.hpp
@@ -26,7 +26,8 @@
 #if defined(BOOST_CLANG)
 # pragma clang diagnostic push
 # if  __has_warning("-Wheader-hygiene")
-#  pragma clang diagnostic ignored "-Wheader-hygiene"
+#  pragma clang diagnostic\
+ ignored "-Wheader-hygiene"
 # endif
 #endif
 

--- a/boost/function/function_base.hpp
+++ b/boost/function/function_base.hpp
@@ -696,7 +696,8 @@ public: // should be protected, but GCC 2.95.3 will fail to allow access
 
 #if defined(BOOST_CLANG)
 #   pragma clang diagnostic push
-#   pragma clang diagnostic ignored "-Wweak-vtables"
+#   pragma clang diagnostic\
+ ignored "-Wweak-vtables"
 #endif
 /**
  * The bad_function_call exception class is thrown when a boost::function

--- a/boost/get_pointer.hpp
+++ b/boost/get_pointer.hpp
@@ -9,11 +9,11 @@
 
 // In order to avoid circular dependencies with Boost.TR1
 // we make sure that our include of <memory> doesn't try to
-// pull in the TR1 headers: that's why we use this header 
+// pull in the TR1 headers: that's why we use this header
 // rather than including <memory> directly:
 #include <boost/config/no_tr1/memory.hpp>  // std::auto_ptr
 
-namespace boost { 
+namespace boost {
 
 // get_pointer(p) extracts a ->* capable pointer from p
 
@@ -41,7 +41,8 @@ template<class T> T * get_pointer(T * p)
 #if defined( BOOST_CORE_DETAIL_DISABLE_LIBSTDCXX_DEPRECATED_WARNINGS )
 // Disable libstdc++ warnings about std::auto_ptr being deprecated in C++11 mode
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic\
+ ignored "-Wdeprecated-declarations"
 #define BOOST_CORE_DETAIL_DISABLED_DEPRECATED_WARNINGS
 #endif
 

--- a/boost/lexical_cast/try_lexical_convert.hpp
+++ b/boost/lexical_cast/try_lexical_convert.hpp
@@ -27,8 +27,10 @@
     !(defined(__INTEL_COMPILER) || defined(__ICL) || defined(__ICC) || defined(__ECC)) && \
     (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)))
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
-#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic\
+ ignored "-Wuninitialized"
+#pragma GCC diagnostic\
+ ignored "-Wsign-conversion"
 #endif
 
 
@@ -81,18 +83,18 @@ namespace boost {
                     boost::is_arithmetic<Source>::value &&
                     boost::is_arithmetic<Target>::value
                 > type;
-        
+
             BOOST_STATIC_CONSTANT(bool, value = (
                 type::value
             ));
         };
 
         /*
-         * is_xchar_to_xchar<Target, Source>::value is true, 
+         * is_xchar_to_xchar<Target, Source>::value is true,
          * Target and Souce are char types of the same size 1 (char, signed char, unsigned char).
          */
         template<typename Target, typename Source>
-        struct is_xchar_to_xchar 
+        struct is_xchar_to_xchar
         {
             typedef boost::integral_constant<
                 bool,
@@ -101,7 +103,7 @@ namespace boost {
                      boost::detail::is_character<Target>::value &&
                      boost::detail::is_character<Source>::value
                 > type;
-                
+
             BOOST_STATIC_CONSTANT(bool, value = (
                 type::value
             ));

--- a/boost/move/detail/std_ns_begin.hpp
+++ b/boost/move/detail/std_ns_begin.hpp
@@ -13,7 +13,8 @@
    #if defined(__clang__)
       #define BOOST_MOVE_STD_NS_GCC_DIAGNOSTIC_PUSH
       #pragma GCC diagnostic push
-      #pragma GCC diagnostic ignored "-Wc++11-extensions"
+      #pragma GCC diagnostic\
+      ignored "-Wc++11-extensions"
    #endif
    #define BOOST_MOVE_STD_NS_BEG _LIBCPP_BEGIN_NAMESPACE_STD
    #define BOOST_MOVE_STD_NS_END _LIBCPP_END_NAMESPACE_STD

--- a/boost/mp11/function.hpp
+++ b/boost/mp11/function.hpp
@@ -199,7 +199,8 @@ template<class... T> using mp_similar = typename detail::mp_similar_impl<T...>::
 
 #if BOOST_MP11_GCC
 # pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wsign-compare"
+# pragma GCC diagnostic\
+ ignored "-Wsign-compare"
 #endif
 
 // mp_less<T1, T2>

--- a/boost/mpl/assert.hpp
+++ b/boost/mpl/assert.hpp
@@ -4,8 +4,8 @@
 
 // Copyright Aleksey Gurtovoy 2000-2006
 //
-// Distributed under the Boost Software License, Version 1.0. 
-// (See accompanying file LICENSE_1_0.txt or copy at 
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 // See http://www.boost.org/libs/mpl for documentation.
@@ -52,8 +52,8 @@
 #   define BOOST_MPL_CFG_ASSERT_BROKEN_POINTER_TO_POINTER_TO_MEMBER
 #endif
 
-// agurt, 10/nov/06: use enums for Borland (which cannot cope with static constants) 
-// and GCC (which issues "unused variable" warnings when static constants are used 
+// agurt, 10/nov/06: use enums for Borland (which cannot cope with static constants)
+// and GCC (which issues "unused variable" warnings when static constants are used
 // at a function scope)
 #if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x610)) \
     || (BOOST_MPL_CFG_GCC != 0) || (BOOST_MPL_CFG_GPU != 0) || defined(__PGI)
@@ -67,7 +67,7 @@ BOOST_MPL_AUX_ADL_BARRIER_NAMESPACE_OPEN
 
 struct failed {};
 
-// agurt, 24/aug/04: MSVC 7.1 workaround here and below: return/accept 
+// agurt, 24/aug/04: MSVC 7.1 workaround here and below: return/accept
 // 'assert<false>' by reference; can't apply it unconditionally -- apparently it
 // degrades the quality of GCC diagnostics
 #if BOOST_WORKAROUND(BOOST_MSVC, == 1310)
@@ -117,7 +117,7 @@ bool operator<=( failed, failed );
 template< bool (*)(failed, failed), long x, long y > struct assert_relation {};
 #   define BOOST_MPL_AUX_ASSERT_RELATION(x, y, r) assert_relation<r,x,y>
 #else
-template< BOOST_MPL_AUX_NTTP_DECL(long, x), BOOST_MPL_AUX_NTTP_DECL(long, y), bool (*)(failed, failed) > 
+template< BOOST_MPL_AUX_NTTP_DECL(long, x), BOOST_MPL_AUX_NTTP_DECL(long, y), bool (*)(failed, failed) >
 struct assert_relation {};
 #   define BOOST_MPL_AUX_ASSERT_RELATION(x, y, r) assert_relation<x,y,r>
 #endif
@@ -133,7 +133,7 @@ boost::mpl::aux::weighted_tag<6>::type operator<=( assert_, assert_ );
 
 template< assert_::relations r, long x, long y > struct assert_relation {};
 
-#endif 
+#endif
 
 #if BOOST_WORKAROUND(BOOST_MSVC, == 1700)
 
@@ -187,7 +187,8 @@ template< typename P > struct assert_arg_pred_not
 #if defined(BOOST_GCC) && BOOST_GCC >= 80000
 #define BOOST_MPL_IGNORE_PARENTHESES_WARNING
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wparentheses"
+#pragma GCC diagnostic\
+ ignored "-Wparentheses"
 #endif
 
 template< typename Pred >
@@ -215,7 +216,7 @@ assert_not_arg( void (*)(Pred), typename assert_arg_pred<Pred>::type );
 
 
 #else // BOOST_MPL_CFG_ASSERT_BROKEN_POINTER_TO_POINTER_TO_MEMBER
-        
+
 template< bool c, typename Pred > struct assert_arg_type_impl
 {
     typedef failed      ************ Pred::* mwcw83_wknd;
@@ -233,11 +234,11 @@ template< typename Pred > struct assert_arg_type
 };
 
 template< typename Pred >
-typename assert_arg_type<Pred>::type 
+typename assert_arg_type<Pred>::type
 assert_arg(void (*)(Pred), int);
 
 template< typename Pred >
-typename assert_arg_type< boost::mpl::not_<Pred> >::type 
+typename assert_arg_type< boost::mpl::not_<Pred> >::type
 assert_not_arg(void (*)(Pred), int);
 
 #   if !defined(BOOST_MPL_CFG_ASSERT_USE_RELATION_NAMES)
@@ -408,7 +409,7 @@ BOOST_MPL_AUX_ASSERT_CONSTANT( \
 #endif
 
 
-// BOOST_MPL_ASSERT_MSG( (pred<x,...>::value), USER_PROVIDED_MESSAGE, (types<x,...>) ) 
+// BOOST_MPL_ASSERT_MSG( (pred<x,...>::value), USER_PROVIDED_MESSAGE, (types<x,...>) )
 
 #if BOOST_WORKAROUND(__MWERKS__, BOOST_TESTED_AT(0x3202))
 #   define BOOST_MPL_ASSERT_MSG_IMPL( counter, c, msg, types_ ) \

--- a/boost/mpl/print.hpp
+++ b/boost/mpl/print.hpp
@@ -5,8 +5,8 @@
 // Copyright David Abrahams 2003
 // Copyright Aleksey Gurtovoy 2004
 //
-// Distributed under the Boost Software License, Version 1.0. 
-// (See accompanying file LICENSE_1_0.txt or copy at 
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 // See http://www.boost.org/libs/mpl for documentation.
@@ -19,7 +19,7 @@
 #include <boost/mpl/identity.hpp>
 
 namespace boost { namespace mpl {
-  
+
 namespace aux {
 #if defined(BOOST_MSVC)
 # pragma warning(push, 3)
@@ -44,27 +44,28 @@ struct print
     : mpl::identity<T>
 #if defined(__MWERKS__)
     , aux::print_base
-#endif 
+#endif
 {
 #if defined(__clang__)
 # pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Wc++11-extensions"
+# pragma clang diagnostic\
+ ignored "-Wc++11-extensions"
     const int m_x = 1 / (sizeof(T) - sizeof(T));
 # pragma clang diagnostic pop
 #elif defined(BOOST_MSVC)
     enum { n = sizeof(T) + -1 };
 #elif defined(__MWERKS__)
     void f(int);
-#else 
+#else
     enum {
         n =
 # if defined(__EDG_VERSION__)
            aux::dependent_unsigned<T>::value > -1
-# else 
+# else
            sizeof(T) > -1
-# endif 
+# endif
         };
-#endif 
+#endif
 };
 
 #if defined(BOOST_MSVC)

--- a/boost/multi_array.hpp
+++ b/boost/multi_array.hpp
@@ -3,7 +3,7 @@
 // Copyright 2018 Glen Joseph Fernandes
 // (glenjofe@gmail.com)
 
-// Use, modification and distribution is subject to the Boost Software 
+// Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
@@ -23,7 +23,8 @@
 
 #if defined(__GNUC__) && ((__GNUC__*100 + __GNUC_MINOR__) >= 406)
 #  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wshadow"
+#  pragma GCC diagnostic\
+ ignored "-Wshadow"
 #endif
 
 #include "boost/multi_array/base.hpp"
@@ -94,7 +95,7 @@ template <>
 struct disable_multi_array_impl_impl<true>
 {
     // forming a pointer to a reference triggers SFINAE
-    typedef int& type; 
+    typedef int& type;
 };
 
 
@@ -153,7 +154,7 @@ public:
     super_type((T*)initial_base_,c_storage_order(),
                /*index_bases=*/0, /*extents=*/0),
     alloc_base(boost::empty_init_t(),alloc) {
-    allocate_space(); 
+    allocate_space();
   }
 
   template <class ExtentList>
@@ -173,7 +174,7 @@ public:
     allocate_space();
   }
 
-    
+
   template <class ExtentList>
   explicit multi_array(ExtentList const& extents,
                        const general_storage_order<NumDims>& so) :
@@ -239,8 +240,8 @@ public:
   // array_view object.  The following constructors ensure that.
   //
 
-  // Due to limited support for partial template ordering, 
-  // MSVC 6&7 confuse the following with the most basic ExtentList 
+  // Due to limited support for partial template ordering,
+  // MSVC 6&7 confuse the following with the most basic ExtentList
   // constructor.
 #ifndef BOOST_NO_FUNCTION_TEMPLATE_ORDERING
   template <typename OPtr>
@@ -404,7 +405,7 @@ public:
     allocate_space();
     std::copy(rhs.begin(),rhs.end(),this->begin());
   }
-    
+
   multi_array(const detail::multi_array::
               multi_array_view<T,NumDims>& rhs,
               const general_storage_order<NumDims>& so,
@@ -415,7 +416,7 @@ public:
     allocate_space();
     std::copy(rhs.begin(),rhs.end(),this->begin());
   }
-    
+
   // Since assignment is a deep copy, multi_array_ref
   // contains all the necessary code.
   template <typename ConstMultiArray>
@@ -444,7 +445,7 @@ public:
       typedef typename gen_type::range range_type;
       ranges.ranges_[i] = range_type(0,extents[i]);
     }
-    
+
     return this->resize(ranges);
   }
 

--- a/boost/multi_index/detail/ignore_wstrict_aliasing.hpp
+++ b/boost/multi_index/detail/ignore_wstrict_aliasing.hpp
@@ -11,7 +11,8 @@
 #if defined(BOOST_GCC)&&(BOOST_GCC>=4*10000+6*100)
 #if !defined(BOOST_MULTI_INDEX_DETAIL_RESTORE_WSTRICT_ALIASING)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#pragma GCC diagnostic\
+ ignored "-Wstrict-aliasing"
 #else
 #pragma GCC diagnostic pop
 #endif

--- a/boost/numeric/odeint/stepper/generation.hpp
+++ b/boost/numeric/odeint/stepper/generation.hpp
@@ -24,12 +24,12 @@
 #include <boost/numeric/odeint/stepper/generation/generation_controlled_runge_kutta.hpp>
 #include <boost/numeric/odeint/stepper/generation/generation_dense_output_runge_kutta.hpp>
 
-#include <boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54_classic.hpp>
+#include <boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54_classi.hpp>
 #include <boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54.hpp>
 #include <boost/numeric/odeint/stepper/generation/generation_runge_kutta_dopri5.hpp>
 #include <boost/numeric/odeint/stepper/generation/generation_runge_kutta_fehlberg78.hpp>
 
-#include <boost/numeric/odeint/stepper/generation/generation_controlled_adams_bashforth_moulton.hpp>
+#include <boost/numeric/odeint/stepper/generation/generation_controlled_adams_bashforth_mou.hpp>
 
 #include <boost/numeric/odeint/stepper/generation/generation_rosenbrock4.hpp>
 

--- a/boost/numeric/odeint/stepper/generation/generation_controlled_adams_bashforth_mou.hpp
+++ b/boost/numeric/odeint/stepper/generation/generation_controlled_adams_bashforth_mou.hpp
@@ -1,5 +1,5 @@
 /*
- boost/numeric/odeint/stepper/detail/generation_controlled_adams_bashforth_moulton.hpp
+ boost/numeric/odeint/stepper/detail/generation_controlled_adams_bashforth_mou.hpp
 
  [begin_description]
  Spezialization of the generation functions for creation of the controlled adams bashforth moulton stepper.

--- a/boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54_classi.hpp
+++ b/boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54_classi.hpp
@@ -1,6 +1,6 @@
 /*
  [auto_generated]
- boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54_classic.hpp
+ boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54_classi.hpp
 
  [begin_description]
  Enable the factory functions for the controller and the dense output of the

--- a/boost/python/detail/wrap_python.hpp
+++ b/boost/python/detail/wrap_python.hpp
@@ -22,7 +22,7 @@
 
 #ifdef _DEBUG
 # ifndef BOOST_DEBUG_PYTHON
-#  ifdef _MSC_VER  
+#  ifdef _MSC_VER
     // VC8.0 will complain if system headers are #included both with
     // and without _DEBUG defined, so we have to #include all the
     // system headers used by pyconfig.h right here.
@@ -166,7 +166,8 @@ typedef int pid_t;
 // Python.h header uses `register` keyword until Python 3.4
 #if BOOST_PYTHON_GCC_HAS_WREGISTER
 # pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wregister"
+# pragma GCC diagnostic\
+ ignored "-Wregister"
 #elif defined(_MSC_VER)
 # pragma warning(push)
 # pragma warning(disable : 5033)  // 'register' is no longer a supported storage class

--- a/boost/smart_ptr/bad_weak_ptr.hpp
+++ b/boost/smart_ptr/bad_weak_ptr.hpp
@@ -40,7 +40,8 @@ namespace boost
 #if defined(BOOST_CLANG)
 // Intel C++ on Mac defines __clang__ but doesn't support the pragma
 # pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Wweak-vtables"
+# pragma clang diagnostic\
+ ignored "-Wweak-vtables"
 #endif
 
 class bad_weak_ptr: public std::exception

--- a/boost/smart_ptr/detail/shared_count.hpp
+++ b/boost/smart_ptr/detail/shared_count.hpp
@@ -33,7 +33,7 @@
 #include <boost/config/workaround.hpp>
 // In order to avoid circular dependencies with Boost.TR1
 // we make sure that our include of <memory> doesn't try to
-// pull in the TR1 headers: that's why we use this header 
+// pull in the TR1 headers: that's why we use this header
 // rather than including <memory> directly:
 #include <boost/config/no_tr1/memory.hpp>  // std::auto_ptr
 #include <functional>       // std::less
@@ -46,7 +46,8 @@
 
 #if defined( BOOST_SP_DISABLE_DEPRECATED )
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic\
+ ignored "-Wdeprecated-declarations"
 #endif
 
 namespace boost
@@ -76,7 +77,7 @@ template< class D > struct sp_inplace_tag
 };
 
 template< class T > class sp_reference_wrapper
-{ 
+{
 public:
 
     explicit sp_reference_wrapper( T & t): t_( boost::addressof( t ) )
@@ -370,7 +371,7 @@ public:
         r.release();
     }
 
-#endif 
+#endif
 
 #if !defined( BOOST_NO_CXX11_SMART_PTR )
 

--- a/boost/smart_ptr/detail/sp_counted_base_clang.hpp
+++ b/boost/smart_ptr/detail/sp_counted_base_clang.hpp
@@ -57,12 +57,13 @@ inline boost::int_least32_t atomic_conditional_increment( atomic_int_least32_t *
         {
             return r;
         }
-    }    
+    }
 }
 
 #if defined(__clang__)
 # pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Wweak-vtables"
+# pragma clang diagnostic\
+ ignored "-Wweak-vtables"
 #endif
 
 class BOOST_SYMBOL_VISIBLE sp_counted_base

--- a/boost/smart_ptr/scoped_ptr.hpp
+++ b/boost/smart_ptr/scoped_ptr.hpp
@@ -24,7 +24,8 @@
 
 #if defined( BOOST_SP_DISABLE_DEPRECATED )
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic\
+ ignored "-Wdeprecated-declarations"
 #endif
 
 namespace boost

--- a/boost/smart_ptr/shared_ptr.hpp
+++ b/boost/smart_ptr/shared_ptr.hpp
@@ -18,7 +18,7 @@
 
 // In order to avoid circular dependencies with Boost.TR1
 // we make sure that our include of <memory> doesn't try to
-// pull in the TR1 headers: that's why we use this header 
+// pull in the TR1 headers: that's why we use this header
 // rather than including <memory> directly:
 #include <boost/config/no_tr1/memory.hpp>  // std::auto_ptr
 
@@ -51,7 +51,8 @@
 
 #if defined( BOOST_SP_DISABLE_DEPRECATED )
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic\
+ ignored "-Wdeprecated-declarations"
 #endif
 
 namespace boost
@@ -256,7 +257,7 @@ template< class T, class R > struct sp_enable_if_auto_ptr
 template< class T, class R > struct sp_enable_if_auto_ptr< std::auto_ptr< T >, R >
 {
     typedef R type;
-}; 
+};
 
 #endif
 
@@ -728,13 +729,13 @@ public:
         BOOST_ASSERT( px != 0 );
         return *px;
     }
-    
+
     typename boost::detail::sp_member_access< T >::type operator-> () const BOOST_SP_NOEXCEPT_WITH_ASSERT
     {
         BOOST_ASSERT( px != 0 );
         return px;
     }
-    
+
     typename boost::detail::sp_array_access< T >::type operator[] ( std::ptrdiff_t i ) const BOOST_SP_NOEXCEPT_WITH_ASSERT
     {
         BOOST_ASSERT( px != 0 );

--- a/boost/tuple/detail/tuple_basic.hpp
+++ b/boost/tuple/detail/tuple_basic.hpp
@@ -43,7 +43,8 @@
 
 #if defined(BOOST_GCC) && (BOOST_GCC >= 40700)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+#pragma GCC diagnostic\
+ ignored "-Wunused-local-typedefs"
 #endif
 
 namespace boost {

--- a/boost/type_traits/detail/has_prefix_operator.hpp
+++ b/boost/type_traits/detail/has_prefix_operator.hpp
@@ -20,7 +20,8 @@
 
 #ifdef BOOST_GCC
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated"
+#pragma GCC diagnostic\
+ ignored "-Wdeprecated"
 #endif
 #if defined(BOOST_MSVC)
 #   pragma warning ( push )

--- a/boost/type_traits/has_logical_not.hpp
+++ b/boost/type_traits/has_logical_not.hpp
@@ -11,7 +11,8 @@
 
 #if defined(__GNUC__) && (__GNUC__*10000 + __GNUC_MINOR__*100 + __GNUC_PATCHLEVEL__ > 40800)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-value"
+#pragma GCC diagnostic\
+ ignored "-Wunused-value"
 #endif
 
 #define BOOST_TT_TRAIT_NAME has_logical_not


### PR DESCRIPTION
`BioCro/src/inc/boost/numeric/odeint/stepper/generation/generation_controlled_adams_bashforth_moulton.hpp`

and

`BioCro/src/inc/boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54_classic.hpp`

become

`BioCro/src/inc/boost/numeric/odeint/stepper/generation/generation_controlled_adams_bashforth_mou.hpp`

and

`BioCro/src/inc/boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54_classi.hpp`